### PR TITLE
Bump dependencies to alpha10

### DIFF
--- a/app/src/main/java/com/bruno/aybar/composechallenges/common/AnimationStateHolder.kt
+++ b/app/src/main/java/com/bruno/aybar/composechallenges/common/AnimationStateHolder.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.AmbientAnimationClock
 import androidx.compose.ui.platform.AnimationClockAmbient
 
 abstract class AnimationStateHolder<T>(initialState: T) {
@@ -41,7 +42,7 @@ abstract class AnimationStateHolder<T>(initialState: T) {
 fun <T> transition(
     definition: TransitionDefinition<T>,
     stateHolder: AnimationStateHolder<T>,
-    clock: AnimationClockObservable = AnimationClockAmbient.current,
+    clock: AnimationClockObservable = AmbientAnimationClock.current,
     label: String? = null,
     onStateChangeFinished: ((T) -> Unit)? = null
 ): TransitionState {
@@ -62,7 +63,7 @@ fun <T> transition(
 fun <T> transition(
     definition: TransitionDefinition<T>,
     stateHolder: AnimationSequenceStateHolder<T>,
-    clock: AnimationClockObservable = AnimationClockAmbient.current,
+    clock: AnimationClockObservable = AmbientAnimationClock.current,
     label: String? = null
 ): TransitionState {
     return androidx.compose.animation.transition(

--- a/app/src/main/java/com/bruno/aybar/composechallenges/flappy/FlappyBirdScreen.kt
+++ b/app/src/main/java/com/bruno/aybar/composechallenges/flappy/FlappyBirdScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.imageResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.material.Text
+import androidx.compose.ui.graphics.graphicsLayer
 import com.bruno.aybar.composechallenges.R
 
 val skyColor = Color(0xFF74B9F5)
@@ -71,10 +72,12 @@ fun GameArea(viewModel: FlappyBirdViewModel, modifier: Modifier) {
             currentState.getObstacles().forEach { obstacle ->
                 DrawObstacle(Modifier
                     .size(obstacle.widthDp.dp, obstacle.heightDp.dp)
-                    .drawLayer(rotationX = when(obstacle.orientation) {
-                        ObstaclePosition.Up -> 180f
-                        ObstaclePosition.Down -> 0f
-                    })
+                    .graphicsLayer {
+                        rotationX = when(obstacle.orientation) {
+                            ObstaclePosition.Up -> 180f
+                            ObstaclePosition.Down -> 0f
+                        }
+                    }
                     .absoluteOffset(
                         x = obstacle.leftMargin.dp,
                         y = obstacle.topMargin.dp
@@ -113,7 +116,7 @@ private fun Bird(state: FlappyGameUi, modifier: Modifier) {
         bitmap = imageResource(id = R.drawable.bird),
         modifier = modifier
             .size(48.dp)
-            .drawLayer(rotationZ = birdRotation)
+            .graphicsLayer { rotationZ = birdRotation }
     )
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,15 +1,15 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.0-alpha08'
+        compose_version = '1.0.0-alpha10'
     }
-    ext.kotlin_version = "1.4.20"
+    ext.kotlin_version = "1.4.21"
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha02'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha07'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Nov 07 23:28:09 PET 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Notables changes:

- `AmbientAnimationClock ` deprecated
- `graphicsLayer ` instead of `drawLayer`